### PR TITLE
Reokace flatten() with async + fix isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,6 @@
 [settings]
-known_first_party=pie
+known_first_party=module,pie
 known_discord=discord
+known_third_party=dhash
 profile=black
 sections=FUTURE,STDLIB,THIRDPARTY,DISCORD,FIRSTPARTY,LOCALFOLDER

--- a/dhash/module.py
+++ b/dhash/module.py
@@ -4,12 +4,12 @@ import time
 from io import BytesIO
 
 import aiohttp
+import dhash
 from PIL import Image
 
 import discord
 from discord.ext import commands
 
-import dhash
 from pie import check, i18n, logger, utils
 
 from .database import HashChannel, HashConfig, ImageHash

--- a/dhash/module.py
+++ b/dhash/module.py
@@ -361,10 +361,9 @@ class Dhash(commands.Cog):
             return
 
         # try to find and delete repost report embed, because we don't have it cached
-        messages = await message.channel.history(
+        async for report in message.channel.history(
             after=message, limit=3, oldest_first=True
-        ).flatten()
-        for report in messages:
+        ):
             if not report.author.bot:
                 continue
             if len(report.embeds) != 1 or type(report.embeds[0].footer.text) is not str:


### PR DESCRIPTION
```
CRITICAL: Uncaught error bubbled-up.
Traceback: 
'async_generator' object has no attribute 'flatten'
  File "/root/.local/lib/python3.11/site-packages/discord/client.py", line 441, in _run_event
    await coro(*args, **kwargs)

  File "/strawberry-py/modules/fun/dhash/module.py", line 366, in on_message_delete
    ).flatten()
      ^^^^^^^
```

This was caused by the old code that was deprecated in Discord.py 2.0 (see https://discordpy.readthedocs.io/en/latest/migrating.html#moving-away-from-custom-asynciterator)


Also, the isort thought that the dhas is firstparty library instead of thirdparty. That (+ the fact that not just pie, but also modules are first party) is fixed.