### PR TITLE
[Macro] Fix guild being None

### DIFF
--- a/macro/module.py
+++ b/macro/module.py
@@ -329,7 +329,7 @@ class Macro(commands.Cog):
     async def on_message(self, message: str):
         if message.author.bot:
             return
-        if message.guild.id not in self._triggers.keys():
+        if not message.guild or message.guild.id not in self._triggers.keys():
             return None
 
         content = message.content.lower()


### PR DESCRIPTION
Fixes

```CRITICAL: Uncaught error bubbled-up.
Traceback: 
'NoneType' object has no attribute 'id'
  File "/root/.local/lib/python3.12/site-packages/discord/client.py", line 449, in _run_event
    await coro(*args, **kwargs)

  File "/strawberry-py/modules/fun/macro/module.py", line 332, in on_message
    if message.guild.id not in self._triggers.keys():
       ^^^^^^^^^^^^^^^^```