### PR TITLE
[Fun] Revert pillow to 10.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-Pillow
+Pillow>=10.4.0,<11.0.0
 dhash
 python-dateutil
 aiohttp


### PR DESCRIPTION
As https://github.com/python-pillow/Pillow/issues/8493 is still not fixed, I had to revert to older version.

After the upper version limit, the docker container must be shut down (`docker compose down`) and brought back again (`docker compose up -d`)