### PR TITLE
[Fun] Requirements - Pillow to 11.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-Pillow>=10.4.0,<11.0.0
+Pillow>=11.1.0
 dhash
 python-dateutil
 aiohttp


### PR DESCRIPTION
There's a new releas of Pillow (11.1.0), which should address the issue with image generators not working.